### PR TITLE
Organisation removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Variablen werden in der Form `{type:name:label}` in den Texten definiert. Hierbe
 - `type` ist optional und kann/sollte einer der folgenden Werte sein: `string`, `number`, `tel`, `email`, `date`
 - `label` kann auch Leerzeichen enthalten und wird der Userin angezeigt
 
+### History
+Organisationen können einen `history` Eintrag (ein `array`) halten. Einzig der type `removed` ist im Moment unterstützt. Beispiel:
+```
+history:
+  - action: removed
+    date: '2021-06-05T00:00:00.000Z'
+    reason: 'Die Firma XY....'
+```
 ## JSON generieren
 ```bash
 nvm use

--- a/data/orgs/MS Direct.yml
+++ b/data/orgs/MS Direct.yml
@@ -3,8 +3,14 @@ address: |-
   MS Direct AG
   Fürstenlandstrasse 35
   9001 St. Gallen
+types:
+  - address
 sources:
   address: https://www.ms-direct.ch/impressum
   privacyStatement: 
     - https://www.ms-direct.ch/disclaimer
     - https://www.ms-direct.ch/datenschutz
+history:
+  - action: removed
+    date: '2021-06-05T00:00:00.000Z'
+    reason: 'Die MS Direct AG pflegt keine eigenen Datenbestände.'

--- a/data/orgs/Rohner Direktpartner.yml
+++ b/data/orgs/Rohner Direktpartner.yml
@@ -10,3 +10,7 @@ sources:
   address: http://www.rohner.biz/kontakt-impressum.html
   privacyStatement: 
   #  - https://www.noSource.ch
+history:
+  - action: removed
+    date: '2021-06-05T00:00:00.000Z'
+    reason: Die Firma Rohner Direktpartner verfügt über keine eigenen Datensammlungen.

--- a/data/orgs/Tanatek.yml
+++ b/data/orgs/Tanatek.yml
@@ -9,3 +9,7 @@ sources:
   address: https://www.tanatekag.ch/impressum/
   privacyStatement: 
     - https://www.tanatekag.ch/datenschutz/
+history:
+  - action: removed
+    date: '2021-06-05T00:00:00.000Z'
+    reason: Die Tanatek AG betreibt keine Datenbanken mit Privatadressen.

--- a/data/orgs/Walter Schmid.yml
+++ b/data/orgs/Walter Schmid.yml
@@ -10,3 +10,7 @@ sources:
   privacyStatement: 
     - https://wsag.ch/files/datenschutzerklaerung_online_1.pdf
     - https://wsag.ch/files/wsag_agb_online_1.pdf
+history:
+  - action: removed
+    date: '2021-06-05T00:00:00.000Z'
+    reason: Die Walter Schmid AG verfügt über keine eigenen Adresslisten.


### PR DESCRIPTION
This marks the following companies as removed:
- MS Direct
- Tanatek AG
- Walter Schmid AG
- Rohner Direktpartner

None of them maintain databases with personal data.

With https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren/pull/18 comes support for this.