### PR TITLE
Create Byjuno.yml

### DIFF
--- a/data/orgs/Byjuno.yml
+++ b/data/orgs/Byjuno.yml
@@ -1,0 +1,16 @@
+name: Byjuno
+address: |-
+  Byjuno AG
+  Datenschutzbeauftragter
+  Industriestrasse 13c
+  6300 Zug
+types:
+  - credit
+  - payback
+privacyStatement:
+  paragraphs:
+    - 'Ersucht wird ausdrücklich eine vollständige Datenauskunft, worunter auch Angaben über mögliche Verknüpfungen im Sinne von «negativen Haushaltstreffern»  (siehe Empfehlung des Eidgenössischen Öffentlichkeits- und Datenschutzbeauftragten vom 17. März 2023 mit Ergänzungen vom 3. Mai 2023) sowie die Erläuterung zur Bonitätsprüfung fallen.'
+sources:
+  address: https://byjuno.ch/de/dataprotection
+  privacyStatement: 
+    - https://byjuno.ch/de/dataprotection


### PR DESCRIPTION
Byjuno ist ein grosser Zahlungsabwickler, der jüngst vom EDÖB gerügt wurde. In der Empfehlung heisst es, dass Auskunft über Betroffenheit von «negativen Haushaltstreffern» über eine gezielte Anfrage möglich ist. Deshalb die Präzisierung im Brief.