### PR TITLE
Extend texts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-
+.idea/
 /node_modules/
 data.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In diesem Repository werden die Daten für den Onlinegenerator für Datenauskunf
 - Organisationen (`/data/orgs`)
 - Arten von Dienstleistungen/Firmen (`/data/types`)
 - Ereignisse (`/data/events`)
+- Aktivitäten des Nachfassens (`/data/followups`)
 
 Pro Organisation/Art/Ereignis wird ein `.yml` file angelegt. Der Filename ist nicht relevant.
 

--- a/data/followups/_template.yml
+++ b/data/followups/_template.yml
@@ -1,0 +1,4 @@
+handle: followup_template
+label: Ich möchte <follow up topic> erreichen
+paragraphs:
+  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.

--- a/data/followups/data_correction.yml
+++ b/data/followups/data_correction.yml
@@ -1,4 +1,8 @@
 handle: data_correction
 label: Ich möchte Daten korrigieren lassen
 paragraphs:
-  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.
+  - Ich danke Ihnen für die Auskunft vom {date:eventDate:Wann}. Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.
+  - Ich ersuche Sie deshalb, dass folgende Personendaten berichtigt werden:
+  - [ Auflistung der zu berichtigenden Daten und gewünschte Berichtigung ]
+  - Ich verlange ferner, dass Sie die Berichtigung Dritten, von welchen Sie die unrichtigen Daten erhalten oder denen Sie die unrichtigen Daten weitergegeben haben, entsprechend informieren.
+  - Ich bitte Sie schliesslich, die Berichtigung zu bestätigen.

--- a/data/followups/data_correction.yml
+++ b/data/followups/data_correction.yml
@@ -1,0 +1,4 @@
+handle: data_correction
+label: Ich möchte Daten korrigieren lassen
+paragraphs:
+  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.

--- a/data/followups/data_deletion.yml
+++ b/data/followups/data_deletion.yml
@@ -1,0 +1,4 @@
+handle: data_deletion
+label: Ich möchte Daten löschen lassen
+paragraphs:
+  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.

--- a/data/followups/data_deletion.yml
+++ b/data/followups/data_deletion.yml
@@ -1,4 +1,8 @@
 handle: data_deletion
 label: Ich möchte Daten löschen lassen
 paragraphs:
-  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.
+  - Ich danke Ihnen für die Auskunft vom {date:eventDate:Wann}.
+  - Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:
+  - [ Auflistung der zu löschenden Daten oder sämtliche Daten ]
+  - Ich verlange ferner, dass Sie die Löschung Dritten, von welchen Sie die zu löschenden Daten erhalten oder denen Sie die zu löschenden Daten weitergegeben haben, entsprechend informieren.
+  - Ich bitte Sie schliesslich, die Löschung zu bestätigen. Sollten Sie die Löschung ganz oder teilweise verweigern, ersuche ich Sie um eine entsprechende Begründung.

--- a/data/followups/incomplete_answer.yml
+++ b/data/followups/incomplete_answer.yml
@@ -1,4 +1,8 @@
 handle: incomplete_answer
 label: Ich habe eine unvollständige Antwort erhalten
 paragraphs:
-  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.
+  - Mein Datenauskunftsbegehren vom {date:eventDate:Wann} wurde mit Ihrer Auskunft vom {date:eventDate:Dann} nicht vollständig beantwortet.
+  - Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen Angaben geliefert werden, wieso eine Auskunft eingeschränkt wurde. Ich bitte Sie entsprechend, vollständig Auskunft zu erteilen oder Angaben zu liefern, wieso die Auskunft eingeschränkt wurde.
+  - Ich gehe davon aus, dass insbesondere folgende Informationen fehlen:
+      - [ Auflistung der fehlenden Daten ]
+  - Sollten Sie weiterhin keine vollständige Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG).

--- a/data/followups/incomplete_answer.yml
+++ b/data/followups/incomplete_answer.yml
@@ -1,0 +1,4 @@
+handle: incomplete_answer
+label: Ich habe eine unvollständige Antwort erhalten
+paragraphs:
+  - Mit Datum vom {date:eventDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt. Mit Ihrer Auskunft vom {date:eventDate:Dann} haben Sie dieses beantwortet.

--- a/data/followups/unanswered.yml
+++ b/data/followups/unanswered.yml
@@ -1,4 +1,6 @@
 handle: unanswered
 label: Ich habe keine Antwort erhalten
 paragraphs:
-  - Mit Datum vom {date:followupDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt, welches bis heute leider unbeantwortet geblieben ist.
+  - Am {date:followupDate:Wann} stellte ich ein Datenauskunftsbegehren, das bis heute unbeantwortet geblieben ist.
+  - Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen die Auskunft oder die Information über eine verzögerte Auskunft innerhalb von 30 Tagen erfolgen. Ebenfalls innerhalb von 30 Tagen muss mitgeteilt werden, wenn die Auskunft verweigert oder aufgeschoben wird.
+  - Ich bitte Sie entsprechend, die Auskunft zu erteilen. Sollten Sie weiterhin keine Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem vorsorglich darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG).

--- a/data/followups/unanswered.yml
+++ b/data/followups/unanswered.yml
@@ -1,0 +1,4 @@
+handle: unanswered
+label: Ich habe keine Antwort erhalten
+paragraphs:
+  - Mit Datum vom {date:followupDate:Wann} habe ich bei Ihnen ein Datenauskunftsbegehren gestellt, welches bis heute leider unbeantwortet geblieben ist.

--- a/tasks/compile-json.mjs
+++ b/tasks/compile-json.mjs
@@ -35,10 +35,22 @@ const events = eventFiles
     return parse(ymlData)
   })
 
+const followupFiles = fs.readdirSync('./data/followups')
+const followups = followupFiles
+    .filter(followupFile => followupFile !== '_template.yml')
+    .map(followupFile => {
+      return fs.readFileSync(`./data/followups/${followupFile}`, { encoding: 'utf-8' })
+    })
+    .map(ymlData => {
+      return parse(ymlData)
+    })
+
+
 const data = {
   types,
   orgs,
-  events
+  events,
+  followups
 }
 
 fs.writeFileSync('data.json', JSON.stringify(data, undefined, 2))


### PR DESCRIPTION
Die Brieftexte sind im "application code" enthalten. Ob sie beim mehrsprachigen Ausbau von dort in "-data" intergriert werden, oder als Textstrukturen im "app code" verbleiben, ist später zu entscheiden. Um der momentanen Hausruhe willen baute ich die Texte hier ein - sie werden aktuell im appcode nicht verwendet. 