### PR TITLE
fix: fix lockfileVersion@v3 warning

### DIFF
--- a/.github/workflows/deployStaging.yml
+++ b/.github/workflows/deployStaging.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
       - run: npm install
 
       - name: Create Json


### PR DESCRIPTION
This fixes the following warning in CI:

> npm WARN read-shrinkwrap This version of npm is compatible with
> lockfileVersion@1, but package-lock.json was generated for
> lockfileVersion@3. I'll try to do my best with it!